### PR TITLE
introduce a summarization based on prediction intervals

### DIFF
--- a/src/bench.mli
+++ b/src/bench.mli
@@ -126,6 +126,14 @@ val print_1d : string -> results list -> unit
     the tests. *)
 val summarize : ?alpha:float -> results list -> unit
 
+(** The function that summarizes the results by comparing the
+ * prediction interval at level alpha of the results
+ * (eg. alpha=0.05 means 95% prediction interval).
+ * Two results are considered to be the same if the prediction interval
+ * of their results' difference includes 0.
+ *)
+val summarize_pi: ?alpha:float -> results list -> unit
+
 (** {6 Configuration API} *)
 
 (** The following global configuration parameters are available for


### PR DESCRIPTION
The summarization based on the t-test produces false-positives
when the difference between the means is very small and the
measurement error/noise larger than the difference.
Introduce a simple summarization function that compares prediction intervals.

It considers two measurements equal if 0 is included in the 95%
prediction intervals of their difference.
